### PR TITLE
Refactor circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,32 +3,21 @@ version: 2
 jobs:
     checkout_code:
         docker:
-            - image: ba78/golang-oracle:0.0.1
+            - image: ba78/golang-oracle:0.0.1   
         steps:
             - checkout
+            - run:
+                name: list dir
+                command: |
+                    ls /root/project
+            - run:
+                name: pwd dir
+                command: |
+                    pwd
             - save_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
                 paths:
                     - ~/project
-    awscli_dependencies:
-        docker:
-            - image: circleci/python:3.6-stretch-node-browsers-legacy
-        working_directory: ~/
-        steps:
-            - restore_cache:
-                key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - restore_cache:
-                key: awscli-{{ checksum "project/.circleci/requirements.txt" }}
-            - run:
-                name: setup dependencies
-                command: |
-                    python3 -m venv venv
-                    . venv/bin/activate
-                    pip install -r project/.circleci/requirements.txt
-            - save_cache: # special step to save dependency cache
-                key: awscli-{{ checksum "project/.circleci/requirements.txt" }}
-                paths:
-                    - "venv"
     oracle_dependencies:
         docker:
             - image: circleci/python:3.6-stretch-node-browsers-legacy
@@ -36,8 +25,6 @@ jobs:
         steps:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-            - restore_cache:
-                key: awscli-{{ checksum "project/.circleci/requirements.txt" }}
             - restore_cache:
                 keys:
                     - oracle-instantclient-v1-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
             requires:
                 - checkout_code
         - build-oracle-image:
-            filters:	
+            filters:
                 branches:	
                     only: master
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,13 +27,13 @@ jobs:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - run:
-                name: ls
-                command: |
-                    ls /usr/lib/pkgconfig
-            - run:
                 name: go install
                 command: |
                     go install
+            - run:
+                name: ls
+                command: |
+                    ls /go/bin
     oracle_dependencies:
         docker:
             - image: circleci/python:3.6-stretch-node-browsers-legacy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ jobs:
             - image: ba78/golang-oracle:0.0.1   
         steps:
             - checkout:
-                path:  /go/src/github.com/dbgeek
+                path:  /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
             - run:
                 name: list dir
                 command: |
-                    ls /root/project
+                    ls /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
             - run:
                 name: pwd dir
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
             - run:
                 name: cp provider binary
                 command: |
-                    cp /go/bin/terraform-provider-oraclerdbms docker/terraform-provider-oraclerdbms/${TERRAFORM_VERSION}"
+                    cp /go/bin/terraform-provider-oraclerdbms docker/terraform-provider-oraclerdbms/${TERRAFORM_VERSION}
             - run:
                 name: building oracle image
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,10 @@ jobs:
                 name: building oracle image
                 command: |
                     docker build -t ba78/terraform-provider-oraclerdbms:"${TERRAFORM_PROVIDER_ORACLERDBMS}" --build-arg TF_VERSION="${TERRAFORM_VERSION}" --build-arg GO_VERSION="${GO_VERSION}" --build-arg TERRAFORM_PROVIDER_ORACLERDBMS="${TERRAFORM_PROVIDER_ORACLERDBMS}" .
+            - run:
+                name: push image to docker hub
+                command: |
+                    docker push ba78/terraform-provider-oraclerdbms:"${TERRAFORM_PROVIDER_ORACLERDBMS}"
 workflows:
   version: 2
   build-and-deploy:
@@ -97,6 +101,9 @@ workflows:
             requires:
                 - checkout_code
         - build-oracle-image:
+            filters:	
+                branches:	
+                    only: master
             requires:
                 - build_terraform_provider_oraclerdbms
                 - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ jobs:
                 name: go install
                 command: |
                     go install
-            - run:
-                name: ls
-                command: |
-                    ls /go/bin
+            - save_cache:
+                key: v1-go-bin-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+                paths:
+                    - /go/bin
     oracle_dependencies:
         docker:
             - image: circleci/python:3.6-stretch-node-browsers-legacy
@@ -62,8 +62,8 @@ jobs:
                     - /home/circleci/artifacts/oracle
     build-oracle-image:
         docker:
-            - image: circleci/python:3.6-stretch-node-browsers-legacy
-        working_directory: ~/project/docker
+            - image: ba78/golang-oracle:0.0.1
+        working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
         environment:
             TERRAFORM_VERSION: 0.11.8
             GO_VERSION: 1.11.1
@@ -73,10 +73,7 @@ jobs:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - restore_cache:
-                key: oracle-unzip-instantclient-v1-cache
-            - restore_cache:
-                keys:
-                    - oracle-instantclient-v1-cache
+                key: v1-go-bin-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - setup_remote_docker:
                 docker_layer_caching: true
             - run: 
@@ -84,34 +81,13 @@ jobs:
                 command: |
                     docker login -u $DOCKER_USER -p $DOCKER_PASS
             - run:
-                name: ls /home/circleci/artifacts/oracle
-                command: echo "$(ls -1 /home/circleci/artifacts/oracle)"
-            - run:
-                name: tar zip 
+                name: cp provider binary
                 command: |
-                    cd ../
-                    tar zcf ../terraform-provider-oraclerdbms.tar.gz . --exclude='./docker/lib/oracle/instantclient_12_2'
-                    mv ../terraform-provider-oraclerdbms.tar.gz docker/
-            - run:
-                name: unzip instantclient
-                command: |
-                    unzip -qq -n /home/circleci/artifacts/oracle/instantclient-basic-linux.x64-"${ORACLE_INSTANT_CLIENT}".zip -d lib/oracle
-                    unzip -qq -n /home/circleci/artifacts/oracle/instantclient-sdk-linux.x64-"${ORACLE_INSTANT_CLIENT}".zip -d lib/oracle
-                    cd lib/oracle/instantclient_12_2
-                    ln libclntsh.so.12.1 libclntsh.so
-                    ln libclntshcore.so.12.1 libclntshcore.so
-            - save_cache:
-                key: oracle-unzip-instantclient-v1-cache
-                paths:
-                    - lib/oracle/instantclient_12_2
+                    cp /go/bin/terraform-provider-oraclerdbms docker/terraform-provider-oraclerdbms/${TERRAFORM_VERSION}"
             - run:
                 name: building oracle image
                 command: |
                     docker build -t ba78/terraform-provider-oraclerdbms:"${TERRAFORM_PROVIDER_ORACLERDBMS}" --build-arg TF_VERSION="${TERRAFORM_VERSION}" --build-arg GO_VERSION="${GO_VERSION}" --build-arg TERRAFORM_PROVIDER_ORACLERDBMS="${TERRAFORM_PROVIDER_ORACLERDBMS}" .
-            - run:
-                name: push image to docker hub
-                command: |
-                    docker push ba78/terraform-provider-oraclerdbms:"${TERRAFORM_PROVIDER_ORACLERDBMS}"
 workflows:
   version: 2
   build-and-deploy:
@@ -119,4 +95,8 @@ workflows:
         - checkout_code
         - build_terraform_provider_oraclerdbms:
             requires:
+                - checkout_code
+        - build-oracle-image:
+            requires:
+                - build_terraform_provider_oraclerdbms
                 - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
                 - checkout_code
         - build-oracle-image:
             filters:
-                branches:	
+                branches:
                     only: master
             requires:
                 - build_terraform_provider_oraclerdbms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
     build-oracle-image:
         docker:
             - image: ba78/golang-oracle:0.0.1
-        working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
+        working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms/docker
         environment:
             TERRAFORM_VERSION: 0.11.8
             GO_VERSION: 1.11.1
@@ -83,7 +83,7 @@ jobs:
             - run:
                 name: cp provider binary
                 command: |
-                    cp /go/bin/terraform-provider-oraclerdbms docker/terraform-provider-oraclerdbms/${TERRAFORM_VERSION}
+                    cp /go/bin/terraform-provider-oraclerdbms ./terraform-provider-oraclerdbms
             - run:
                 name: building oracle image
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,6 @@ jobs:
         docker:
             - image: ba78/golang-oracle:0.0.1
         working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
-        environment:
-            LD_LIBRARY_PATH: /usr/lib/instantclient_12_2
-            ORACLE_HOME: /usr/lib/instantclient_12_2
-            PKG_CONFIG_PATH: /usr/lib/pkgconfig
         steps:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     checkout_code:
         docker:
-            - image: circleci/python:3.6-stretch-node-browsers-legacy
+            - image: ba78/golang-oracle:0.0.1
         steps:
             - checkout
             - save_cache:
@@ -114,13 +114,3 @@ workflows:
   build-and-deploy:
     jobs:
         - checkout_code
-        - awscli_dependencies:
-            requires:
-                - checkout_code
-        - oracle_dependencies:
-            requires:
-                - checkout_code
-                - awscli_dependencies
-        - build-oracle-image:
-            requires:
-                - oracle_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ jobs:
         docker:
             - image: ba78/golang-oracle:0.0.1   
         steps:
-            - checkout
+            - checkout:
+                path:  /go/src/github.com/dbgeek
             - run:
                 name: list dir
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ jobs:
         docker:
             - image: ba78/golang-oracle:0.0.1
         working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
+        environment:
+            LD_LIBRARY_PATH: /usr/lib/instantclient_12_2
+            ORACLE_HOME: /usr/lib/instantclient_12_2
+            PKG_CONFIG_PATH: /usr/lib/pkgconfig
         steps:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
             - restore_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - run:
+                name: ls
+                command: |
+                    ls /usr/lib/pkgconfig
+            - run:
                 name: go install
                 command: |
                     go install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     checkout_code:
         docker:
-            - image: ba78/golang-oracle:0.0.1   
+            - image: ba78/golang-oracle:0.0.1
         steps:
             - checkout:
                 path:  /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
@@ -18,7 +18,18 @@ jobs:
             - save_cache:
                 key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
                 paths:
-                    - ~/project
+                    - /go/src/github.com/dbgeek
+    build_terraform_provider_oraclerdbms:
+        docker:
+            - image: ba78/golang-oracle:0.0.1
+        working_directory: /go/src/github.com/dbgeek/terraform-provider-oraclerdbms
+        steps:
+            - restore_cache:
+                key: v1-repo-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
+            - run:
+                name: go install
+                command: |
+                    go install
     oracle_dependencies:
         docker:
             - image: circleci/python:3.6-stretch-node-browsers-legacy
@@ -102,3 +113,6 @@ workflows:
   build-and-deploy:
     jobs:
         - checkout_code
+        - build_terraform_provider_oraclerdbms:
+            requires:
+                - checkout_code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,7 @@
-FROM oraclelinux:7-slim AS builder
-
-LABEL maintainer="Björn Ahl <bnal@kba78.me>"
-ARG GIT_COMMIT=unspecified
-ARG TF_VERSION
-ARG GO_VERSION
-
-ENV LD_LIBRARY_PATH /usr/lib/instantclient_12_2
-ENV ORACLE_HOME /usr/lib/instantclient_12_2
-ENV PATH=$PATH:/usr/local/go/bin
-ENV PKG_CONFIG_PATH /usr/lib/pkgconfig
-ENV GOPATH /go
-ENV TNS_ADMIN /usr/lib/instantclient_12_2/network/admin
-
-RUN yum -y install gzip tar pkg-config git gcc libaio && \
-    yum clean all && \
-	rm -rf /var/cache/yum
-
-COPY ./lib/oracle/instantclient_12_2 /usr/lib/instantclient_12_2
-COPY ./lib/oracle/oci8.pc /usr/lib/pkgconfig/oci8.pc
-COPY ./go${GO_VERSION}.linux-amd64.tar.gz.sha256 go${GO_VERSION}.linux-amd64.tar.gz.sha256
-COPY terraform-provider-oraclerdbms.tar.gz $GOPATH/src/github.com/dbgeek/terraform-provider-oraclerdbms/terraform-provider-oraclerdbms.tar.gz
-COPY ./hashicorp.asc /tmp/hashicorp.asc
-
-RUN curl -s -O https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    sha256sum -c go${GO_VERSION}.linux-amd64.tar.gz.sha256 && \
-    tar -C /usr/local/ -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm -f go${GO_VERSION}.linux-amd64.tar.gz && \
-    cd "$GOPATH/src/github.com/dbgeek/terraform-provider-oraclerdbms" && \
-    tar xzf terraform-provider-oraclerdbms.tar.gz && \
-    rm terraform-provider-oraclerdbms.tar.gz
-
-WORKDIR $GOPATH/src/github.com/dbgeek/terraform-provider-oraclerdbms
-
-RUN go install
-
-FROM oraclelinux:7-slim
+FROM ba78/terraform-oracle-base:0.0.1
 ARG TF_VERSION
 ARG TERRAFORM_PROVIDER_ORACLERDBMS
-LABEL maintainer="Björn Ahl <bnal@kba78.me>"
+LABEL maintainer="Björn Ahl <bnal@ba78.me>"
 
 ENV USER=tf
 ENV LD_LIBRARY_PATH /usr/lib/instantclient_12_2
@@ -47,10 +11,8 @@ ENV PKG_CONFIG_PATH /usr/lib/pkgconfig
 ENV GOPATH /go
 ENV TNS_ADMIN /usr/lib/instantclient_12_2/network/admin
 
-COPY ./lib/oracle/instantclient_12_2 /usr/lib/instantclient_12_2
-COPY ./lib/oracle/oci8.pc /usr/lib/pkgconfig/oci8.pc
-COPY --from=builder /go/bin/terraform-provider-oraclerdbms /home/tf/.terraform.d/plugins/linux_amd64/terraform-provider-oraclerdbms_v${TERRAFORM_PROVIDER_ORACLERDBMS}
-COPY --from=builder /tmp/hashicorp.asc .
+COPY ./terraform-provider-oraclerdbms /home/tf/.terraform.d/plugins/linux_amd64/terraform-provider-oraclerdbms_v${TERRAFORM_PROVIDER_ORACLERDBMS}
+COPY ./hashicorp.asc .
 
 RUN yum -y install pkg-config libaio unzip && \
     yum clean all && \


### PR DESCRIPTION
Do not build provider inside docker container. From now I use custom image for circleci that have go oracle etc installed. This makes it possible to run test later.